### PR TITLE
Fix broken docker build

### DIFF
--- a/octoprint_preprintservice/__init__.py
+++ b/octoprint_preprintservice/__init__.py
@@ -19,7 +19,6 @@ except:
 	from profile import Profile
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-blueprint = flask.Blueprint("plugin.preprintservice", __name__)
 
 
 class PreprintservicePlugin(octoprint.plugin.SlicerPlugin,

--- a/preprintservice_src/Dockerfile
+++ b/preprintservice_src/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.8
-MAINTAINER Christoph Schranz <christoph.schranz@salzburgresearch.at>
+LABEL maintainer="Christoph Schranz <christoph.schranz@salzburgresearch.at>"
 
 RUN mkdir /tmp || true
 

--- a/preprintservice_src/Dockerfile
+++ b/preprintservice_src/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.8
 MAINTAINER Christoph Schranz <christoph.schranz@salzburgresearch.at>
 
 RUN mkdir /tmp || true
@@ -8,7 +8,7 @@ RUN mkdir /tmp || true
 RUN apt-get update && apt-get install -y \
   freeglut3 \
   libgtk2.0-dev \
-  libwxgtk3.0-dev \
+  libwxgtk3.0-gtk3-dev \
   libwx-perl \
   libxmu-dev \
   libgl1-mesa-glx \
@@ -54,7 +54,7 @@ ADD . /src/.
 # Clone if Tweaker-3 doesn't exist, and pull.
 RUN ls /src/Tweaker-3/README.md  > /dev/null 2>&1  \
   || (echo "Tweaker not found, cloning repository" \
-    && git clone https://github.com/ChristophSchranz/Tweaker-3 /src/Tweaker-3) \
+  && git clone https://github.com/ChristophSchranz/Tweaker-3 /src/Tweaker-3) \
   && cd /src/Tweaker-3 \
   && git pull
 

--- a/preprintservice_src/requirements.txt
+++ b/preprintservice_src/requirements.txt
@@ -1,4 +1,3 @@
-Flask==1.0.2
-Werkzeug==0.15.3
+Flask==2.1.3
 numpy==1.22.0
-requests==2.21.0
+requests==2.26.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,9 @@
 # works as expected. Requirements can be found in setup.py.
 ###
 
-Flask~=1.1.2
-requests~=2.25.0
+Flask==2.1.3
+requests==2.26.0
 urllib3~=1.26.2
 OctoPrint>=1.8.0
 setuptools~=50.3.2
 numpy~=1.22.0
-Werkzeug~=1.0.1


### PR DESCRIPTION
Hello! I love the plugin, very useful. I tried to install it today and ran into a couple of versioning issues, so I made some updates to get everything to build in Docker. 

## Changes

### Docker

- Removed deprecated `MAINTAINER` command in favor of `LABEL`
- `libwxgtk3.0-dev` is now packaged under `libwxgtk3.0-gtk3-dev`
- `python:3.6` -> `python:3.8` since numpy 1.22.0 requires Python >= 3.8

### Pip
- `Flask==1.0.2` -> `Flask==2.1.3` since OctoPrint >= 1.8.0 requires Flask >= 2, < 3
- `requests~=2.25.0` -> `requests==2.26.0` since OctoPrint >= 1.8.0 requires requests >= 2.26.0, < 3
- Removed `Werkzeug` since it's installed by Flask.

### Code
- Removed unused Blueprint initialization since it was unused, and new versions of Flask do not allow dots in the name of a blueprint.