### PR TITLE
Fix the source image

### DIFF
--- a/preprintservice_src/Dockerfile
+++ b/preprintservice_src/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.8-bullseye
 LABEL maintainer="Christoph Schranz <christoph.schranz@salzburgresearch.at>"
 
 RUN mkdir /tmp || true


### PR DESCRIPTION
make the docker image buildable by switching to the bullseye python image instead of the new bookworm image with missing dependencies